### PR TITLE
Apply the priority and accepted args as arguments

### DIFF
--- a/premium/ecommerce/skip-old-orders.php
+++ b/premium/ecommerce/skip-old-orders.php
@@ -5,4 +5,4 @@ add_filter( 'mc4wp_ecommerce_send_order_to_mailchimp', function( $send, WC_Order
     $time_order_completed = strtotime( $order->get_date_completed() );
     $send = ( $time_order_completed > $time_one_month_ago );
     return $send;
-});
+}, 10, 2);


### PR DESCRIPTION
Wordpress would not inject the second argument if you dont define the
accepted args
Add the required arguments to inject the arguments in the callable
https://developer.wordpress.org/reference/functions/add_filter/